### PR TITLE
Adding NUMJOBS variable.

### DIFF
--- a/base/caja/caja.SlackBuild
+++ b/base/caja/caja.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -90,7 +91,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-introspection \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/engrampa/engrampa.SlackBuild
+++ b/base/engrampa/engrampa.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-packagekit \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/eom/eom.SlackBuild
+++ b/base/eom/eom.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -89,7 +90,7 @@ CXXFLAGS="$SLKCFLAGS" \
 # This is needed in -current, but should be harmless in -stable as well
 sed -i "s|--strict --dry-run|--dry-run|" data/Makefile
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/libmatekbd/libmatekbd.SlackBuild
+++ b/base/libmatekbd/libmatekbd.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/libmatemixer/libmatemixer.SlackBuild
+++ b/base/libmatemixer/libmatemixer.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/libmateweather/libmateweather.SlackBuild
+++ b/base/libmateweather/libmateweather.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-locations-compression \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/marco/marco.SlackBuild
+++ b/base/marco/marco.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/mate-backgrounds/mate-backgrounds.SlackBuild
+++ b/base/mate-backgrounds/mate-backgrounds.SlackBuild
@@ -36,6 +36,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -80,7 +81,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-common/mate-common.SlackBuild
+++ b/base/mate-common/mate-common.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-control-center/mate-control-center.SlackBuild
+++ b/base/mate-control-center/mate-control-center.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-appindicator=auto \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/mate-desktop/mate-desktop.SlackBuild
+++ b/base/mate-desktop/mate-desktop.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-introspection \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/mate-icon-theme/mate-icon-theme.SlackBuild
+++ b/base/mate-icon-theme/mate-icon-theme.SlackBuild
@@ -36,6 +36,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 set -e
 
@@ -63,7 +64,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-media/mate-media.SlackBuild
+++ b/base/mate-media/mate-media.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-menus/mate-menus.SlackBuild
+++ b/base/mate-menus/mate-menus.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/mate-notification-daemon/mate-notification-daemon.SlackBuild
+++ b/base/mate-notification-daemon/mate-notification-daemon.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --libexecdir=/usr/lib${LIBDIRSUFFIX}/mate-notification-daemon \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-panel/mate-panel.SlackBuild
+++ b/base/mate-panel/mate-panel.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -89,7 +90,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-introspection=yes \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/base/mate-polkit/mate-polkit.SlackBuild
+++ b/base/mate-polkit/mate-polkit.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-power-manager/mate-power-manager.SlackBuild
+++ b/base/mate-power-manager/mate-power-manager.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --libexecdir=/usr/lib${LIBDIRSUFFIX}/mate-power-manager \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-screensaver/mate-screensaver.SlackBuild
+++ b/base/mate-screensaver/mate-screensaver.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-pam \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-session-manager/mate-session-manager.SlackBuild
+++ b/base/mate-session-manager/mate-session-manager.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --without-systemd \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Add xinitrc for xwmconfig

--- a/base/mate-settings-daemon/mate-settings-daemon.SlackBuild
+++ b/base/mate-settings-daemon/mate-settings-daemon.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-system-monitor/mate-system-monitor.SlackBuild
+++ b/base/mate-system-monitor/mate-system-monitor.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-systemd \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-terminal/mate-terminal.SlackBuild
+++ b/base/mate-terminal/mate-terminal.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/base/mate-themes/mate-themes.SlackBuild
+++ b/base/mate-themes/mate-themes.SlackBuild
@@ -36,6 +36,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -80,7 +81,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/gksu/gksu.SlackBuild
+++ b/deps/gksu/gksu.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -89,7 +90,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-nautilus-extension=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/glade/glade.SlackBuild
+++ b/deps/glade/glade.SlackBuild
@@ -43,6 +43,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ LDFLAGS="-L/usr/lib${LIBDIRSUFFIX}" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/graphviz/graphviz.SlackBuild
+++ b/deps/graphviz/graphviz.SlackBuild
@@ -45,6 +45,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -99,7 +100,7 @@ LDFLAGS="-L/usr/lib${LIBDIRSUFFIX}" \
   --enable-php=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install-strip DESTDIR=$PKG
 
 # Install config file for PHP.

--- a/deps/gssdp/gssdp.SlackBuild
+++ b/deps/gssdp/gssdp.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/gtk-engines/gtk-engines.SlackBuild
+++ b/deps/gtk-engines/gtk-engines.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-deprecated \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/gtksourceview3/gtksourceview3.SlackBuild
+++ b/deps/gtksourceview3/gtksourceview3.SlackBuild
@@ -44,6 +44,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"

--- a/deps/gupnp/gupnp.SlackBuild
+++ b/deps/gupnp/gupnp.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/libgksu/libgksu.SlackBuild
+++ b/deps/libgksu/libgksu.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -101,7 +102,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/libgtop/libgtop.SlackBuild
+++ b/deps/libgtop/libgtop.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -91,7 +92,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-hacker-mode \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/libgxps/libgxps.SlackBuild
+++ b/deps/libgxps/libgxps.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"

--- a/deps/libpeas/libpeas.SlackBuild
+++ b/deps/libpeas/libpeas.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -91,7 +92,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-gtk \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/libunique/libunique.SlackBuild
+++ b/deps/libunique/libunique.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -97,7 +98,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-maintainer-flags \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/libunique3/libunique3.SlackBuild
+++ b/deps/libunique3/libunique3.SlackBuild
@@ -46,6 +46,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -93,7 +94,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-debug=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/libwnck3/libwnck3.SlackBuild
+++ b/deps/libwnck3/libwnck3.SlackBuild
@@ -46,6 +46,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -94,7 +95,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-introspection=yes \
   --build=$ARCH-slackware-linux
 
-make $NUMJOBS || make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/murrine/murrine.SlackBuild
+++ b/deps/murrine/murrine.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-animation \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/pangox-compat/pangox-compat.SlackBuild
+++ b/deps/pangox-compat/pangox-compat.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=${PKG:-${TMP}/package-$PRGNAM}
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CFLAGS="$SLKCFLAGS" \
   --host=$ARCH-slackware-linux \
   --target=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 
 # Check the host value that is passed to the compile to the one in this script:
 host="$ARCH-slackware-linux-gnu"

--- a/deps/rarian/rarian.SlackBuild
+++ b/deps/rarian/rarian.SlackBuild
@@ -43,6 +43,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -88,7 +89,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/vala/vala.SlackBuild
+++ b/deps/vala/vala.SlackBuild
@@ -43,6 +43,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -85,7 +86,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --libdir=/usr/lib${LIBDIRSUFFIX} \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install-strip DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/deps/yelp-tools/yelp-tools.SlackBuild
+++ b/deps/yelp-tools/yelp-tools.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/yelp-xsl/yelp-xsl.SlackBuild
+++ b/deps/yelp-xsl/yelp-xsl.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/deps/zenity/zenity.SlackBuild
+++ b/deps/zenity/zenity.SlackBuild
@@ -23,6 +23,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -68,7 +69,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-libnotify \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install-strip DESTDIR=$PKG
 
 find $PKG/usr/man -type f -exec gzip -9 {} \;

--- a/extra/atril/atril.SlackBuild
+++ b/extra/atril/atril.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -101,7 +102,7 @@ CPPFLAGS="-I/usr/share/texmf/include" \
   $epub \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/extra/caja-actions/caja-actions.SlackBuild
+++ b/extra/caja-actions/caja-actions.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -84,7 +85,7 @@ find -L . \
   --with-gtk=3 \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG pkgdocdir=/usr/doc/$PRGNAM-$VERSION
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/caja-dropbox/caja-dropbox.SlackBuild
+++ b/extra/caja-dropbox/caja-dropbox.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-static=no \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/caja-extensions/caja-extensions.SlackBuild
+++ b/extra/caja-extensions/caja-extensions.SlackBuild
@@ -41,6 +41,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -91,7 +92,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-share \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/mate-applets/mate-applets.SlackBuild
+++ b/extra/mate-applets/mate-applets.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -96,7 +97,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --enable-suid=yes \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/mate-calc/mate-calc.SlackBuild
+++ b/extra/mate-calc/mate-calc.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --without-help-dir \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/mate-icon-theme-faenza/mate-icon-theme-faenza.SlackBuild
+++ b/extra/mate-icon-theme-faenza/mate-icon-theme-faenza.SlackBuild
@@ -36,6 +36,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -80,7 +81,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/mate-sensors-applet/mate-sensors-applet.SlackBuild
+++ b/extra/mate-sensors-applet/mate-sensors-applet.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -87,7 +88,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --disable-static \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/extra/mate-utils/mate-utils.SlackBuild
+++ b/extra/mate-utils/mate-utils.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -96,7 +97,7 @@ sed -i "s|--strict --dry-run|--dry-run|" gsearchtool/Makefile
 sed -i "s|--strict --dry-run|--dry-run|" mate-screenshot/Makefile
 sed -i "s|--strict --dry-run|--dry-run|" mate-dictionary/data/Makefile
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 # Don't ship .la files:

--- a/extra/mozo/mozo.SlackBuild
+++ b/extra/mozo/mozo.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -86,7 +87,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --build=$ARCH-slackware-linux
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \

--- a/extra/pluma/pluma.SlackBuild
+++ b/extra/pluma/pluma.SlackBuild
@@ -42,6 +42,7 @@ CWD=$(pwd)
 TMP=${TMP:-/tmp/msb}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
+NUMJOBS=${NUMJOBS:-" "}
 
 if [ "$ARCH" = "i586" ]; then
   SLKCFLAGS="-O2 -march=i586 -mtune=i686"
@@ -89,7 +90,7 @@ CXXFLAGS="$SLKCFLAGS" \
 # This is needed in -current, but should be harmless in -stable as well
 sed -i "s|--strict --dry-run|--dry-run|" data/Makefile
 
-make
+make $NUMJOBS
 make install DESTDIR=$PKG
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \


### PR DESCRIPTION
Adding NUMJOBS variable (defaults to ' ' ).
This will allow the user to specifies the number of jobs (commands) to run simultaneously, while doing make.

All builds ware tested on x86_64 & ARM and build without any errors/issues.